### PR TITLE
feat: added account dropdown with profile, settings, and logout

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Logo from "../assets/logo.svg";
-import { Upload, Folder, FileText, Settings, Search, MoreVertical, Home, Clock, Star, Trash2, Users, HardDrive, Download, Share2, AlertTriangle} from 'lucide-react';
+import { Upload, Folder, FileText, Settings, Search, MoreVertical, Home, Clock, Star, Trash2, Users, HardDrive, Download, Share2, AlertTriangle, LogOut, User } from 'lucide-react';
 import { api } from '../api';
-import { getToken } from "../tokenStore";
+import { getToken, clearToken } from "../tokenStore";
 
 export default function Dashboard() {
     const navigate = useNavigate();
@@ -15,54 +15,41 @@ export default function Dashboard() {
     const [storageStats, setStorageStats] = useState({ total_files: 0, total_mb: 0 });
     const [uploading, setUploading] = useState(false);
     const fileInputRef = useRef(null);
+    const [showAccountMenu, setShowAccountMenu] = useState(false);
 
-    // Fetch user data when component loads
     useEffect(() => {
         const fetchUserData = async () => {
             const token = getToken();
-            
-            // If no token, redirect to login
             if (!token) {
                 navigate("/login");
                 return;
             }
-
             try {
                 const response = await fetch("http://localhost:8000/api/v1/auth/me", {
-                    headers: {
-                        "Authorization": `Bearer ${token}`
-                    }
+                    headers: { "Authorization": `Bearer ${token}` }
                 });
-
                 if (response.ok) {
                     const data = await response.json();
                     setUser(data);
                 } else {
-                    // Token invalid, redirect to login
                     navigate("/login");
                 }
             } catch (error) {
                 console.error("Failed to fetch user data:", error);
-                // Backend might be down - stay on page but log error
             }
         };
-
         fetchUserData();
     }, [navigate]);
 
-    // Load files when component mounts
     useEffect(() => {
         loadFiles();
         loadStorageStats();
     }, []);
 
-    // Fetch files from backend
     async function loadFiles() {
         try {
             setLoading(true);
             const data = await api.getFiles({ limit: 100, sort_by: 'created_at', sort_order: 'desc' });
-            
-            // Convert backend format to UI format
             const formattedFiles = data.items.map(item => ({
                 id: item.file_id,
                 name: item.name,
@@ -71,7 +58,6 @@ export default function Dashboard() {
                 modified: formatDate(item.created_at),
                 isFolder: !!item.folder
             }));
-            
             setFiles(formattedFiles);
         } catch (error) {
             console.error('Failed to load files:', error);
@@ -81,7 +67,6 @@ export default function Dashboard() {
         }
     }
 
-    // Fetch storage stats
     async function loadStorageStats() {
         try {
             const stats = await api.getStorageStats();
@@ -91,11 +76,9 @@ export default function Dashboard() {
         }
     }
 
-    // Handle file upload
     async function handleFileUpload(event) {
         const selectedFile = event.target.files[0];
         if (!selectedFile) return;
-
         try {
             setUploading(true);
             await api.uploadFile(selectedFile);
@@ -111,7 +94,6 @@ export default function Dashboard() {
         }
     }
 
-    // Helper functions
     function getFileType(filename) {
         const ext = filename.split('.').pop().toUpperCase();
         return ext || 'FILE';
@@ -132,7 +114,6 @@ export default function Dashboard() {
         const diffMins = Math.floor(diffMs / 60000);
         const diffHours = Math.floor(diffMs / 3600000);
         const diffDays = Math.floor(diffMs / 86400000);
-
         if (diffMins < 60) return `${diffMins} minutes ago`;
         if (diffHours < 24) return `${diffHours} hours ago`;
         if (diffDays === 1) return 'Yesterday';
@@ -150,13 +131,12 @@ export default function Dashboard() {
 
     const storagePercentage = (storageStats.total_mb / 10240) * 100;
 
-    // Show loading while fetching user data
     if (!user && loading) {
         return (
-            <div style={{ 
-                display: "flex", 
-                alignItems: "center", 
-                justifyContent: "center", 
+            <div style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
                 height: "100vh",
                 fontSize: "1.2rem",
                 color: "#666"
@@ -168,6 +148,7 @@ export default function Dashboard() {
 
     return (
         <div style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0, display: "flex", height: "100vh", backgroundColor: "#f5f5f5", fontFamily: "system-ui, -apple-system, sans-serif" }}>
+
             {/* Sidebar */}
             <div style={{
                 width: "260px",
@@ -178,21 +159,13 @@ export default function Dashboard() {
                 padding: "16px"
             }}>
                 <div style={{ marginBottom: "24px", display: "flex", alignItems: "center", gap: "10px" }}>
-                    <img 
-                        src={Logo} 
-                        alt="Secure Drive logo" 
-                        style={{ width: "32px", height: "32px" }} 
-                    />
+                    <img src={Logo} alt="Secure Drive logo" style={{ width: "32px", height: "32px" }} />
                     <span style={{ fontSize: "1.1rem", fontWeight: 700 }}>Secure Drive</span>
                 </div>
 
-                <input
-                    type="file"
-                    ref={fileInputRef}
-                    onChange={handleFileUpload}
-                    style={{ display: 'none' }}
-                />
-                <button 
+                <input type="file" ref={fileInputRef} onChange={handleFileUpload} style={{ display: 'none' }} />
+
+                <button
                     onClick={() => fileInputRef.current?.click()}
                     disabled={uploading}
                     style={{
@@ -211,12 +184,8 @@ export default function Dashboard() {
                         marginBottom: "16px",
                         width: "100%"
                     }}
-                    onMouseOver={(e) => {
-                        if (!uploading) e.target.style.backgroundColor = "#4338CA";
-                    }}
-                    onMouseOut={(e) => {
-                        if (!uploading) e.target.style.backgroundColor = "#4F46E5";
-                    }}
+                    onMouseOver={(e) => { if (!uploading) e.target.style.backgroundColor = "#4338CA"; }}
+                    onMouseOut={(e) => { if (!uploading) e.target.style.backgroundColor = "#4F46E5"; }}
                 >
                     <Upload size={20} />
                     {uploading ? 'Uploading...' : 'Upload'}
@@ -237,12 +206,8 @@ export default function Dashboard() {
                                 backgroundColor: item.active ? "#EEF2FF" : "transparent",
                                 color: item.active ? "#4F46E5" : "#666"
                             }}
-                            onMouseOver={(e) => {
-                                if (!item.active) e.currentTarget.style.backgroundColor = "#f5f5f5";
-                            }}
-                            onMouseOut={(e) => {
-                                if (!item.active) e.currentTarget.style.backgroundColor = "transparent";
-                            }}
+                            onMouseOver={(e) => { if (!item.active) e.currentTarget.style.backgroundColor = "#f5f5f5"; }}
+                            onMouseOut={(e) => { if (!item.active) e.currentTarget.style.backgroundColor = "transparent"; }}
                         >
                             <item.icon size={20} />
                             <span style={{ fontSize: "0.95rem", fontWeight: item.active ? 600 : 400 }}>
@@ -252,29 +217,13 @@ export default function Dashboard() {
                     ))}
                 </div>
 
-                <div style={{
-                    marginTop: "auto",
-                    padding: "16px",
-                    backgroundColor: "#f9fafb",
-                    borderRadius: "8px"
-                }}>
+                <div style={{ marginTop: "auto", padding: "16px", backgroundColor: "#f9fafb", borderRadius: "8px" }}>
                     <div style={{ display: "flex", alignItems: "center", marginBottom: "8px", gap: "8px" }}>
                         <HardDrive size={16} color="#666" />
                         <span style={{ fontSize: "0.875rem", color: "#666" }}>Storage</span>
                     </div>
-                    <div style={{
-                        width: "100%",
-                        height: "6px",
-                        backgroundColor: "#e0e0e0",
-                        borderRadius: "4px",
-                        marginBottom: "8px"
-                    }}>
-                        <div style={{
-                            width: `${Math.min(storagePercentage, 100)}%`,
-                            height: "100%",
-                            backgroundColor: "#4F46E5",
-                            borderRadius: "4px"
-                        }} />
+                    <div style={{ width: "100%", height: "6px", backgroundColor: "#e0e0e0", borderRadius: "4px", marginBottom: "8px" }}>
+                        <div style={{ width: `${Math.min(storagePercentage, 100)}%`, height: "100%", backgroundColor: "#4F46E5", borderRadius: "4px" }} />
                     </div>
                     <span style={{ fontSize: "0.75rem", color: "#999" }}>
                         {storageStats.total_mb.toFixed(2)} MB of 10 GB used
@@ -284,6 +233,8 @@ export default function Dashboard() {
 
             {/* Main Content */}
             <div style={{ flexGrow: 1, display: "flex", flexDirection: "column" }}>
+
+                {/* Top Bar */}
                 <div style={{
                     backgroundColor: "#ffffff",
                     borderBottom: "1px solid #e0e0e0",
@@ -305,47 +256,136 @@ export default function Dashboard() {
                         <input
                             type="text"
                             placeholder="Search in Drive"
-                            style={{
-                                border: "none",
-                                backgroundColor: "transparent",
-                                outline: "none",
-                                width: "100%",
-                                fontSize: "0.95rem"
-                            }}
+                            style={{ border: "none", backgroundColor: "transparent", outline: "none", width: "100%", fontSize: "0.95rem" }}
                         />
                     </div>
 
-                    <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
-                        <button style={{
-                            width: "40px",
-                            height: "40px",
-                            borderRadius: "50%",
-                            border: "none",
-                            backgroundColor: "transparent",
-                            cursor: "pointer",
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center"
-                        }}>
-                            <Settings size={22} color="#666" />
-                        </button>
-                        <div style={{
-                            width: "36px",
-                            height: "36px",
-                            borderRadius: "50%",
-                            backgroundColor: "#4F46E5",
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            color: "white",
-                            fontWeight: 600,
-                            fontSize: "0.9rem"
-                        }}>
-                            {user?.name?.charAt(0).toUpperCase() || "U"}
+                        {/* Account Circle + Dropdown */}
+                        <div style={{ position: "relative" }}>
+                            <div
+                                onClick={() => setShowAccountMenu(!showAccountMenu)}
+                                style={{
+                                    width: "36px",
+                                    height: "36px",
+                                    borderRadius: "50%",
+                                    backgroundColor: "#4F46E5",
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    color: "white",
+                                    fontWeight: 600,
+                                    fontSize: "0.9rem",
+                                    cursor: "pointer"
+                                }}
+                            >
+                                {user?.name?.charAt(0).toUpperCase() || "U"}
+                            </div>
+
+                            {showAccountMenu && (
+                                <div style={{
+                                    position: "absolute",
+                                    right: 0,
+                                    top: "44px",
+                                    backgroundColor: "white",
+                                    boxShadow: "0 8px 24px rgba(0,0,0,0.15)",
+                                    borderRadius: "12px",
+                                    padding: "8px",
+                                    minWidth: "260px",
+                                    zIndex: 100,
+                                    border: "1px solid #e0e0e0"
+                                }}>
+                                    {/* User Card */}
+                                    <div style={{
+                                        padding: "20px",
+                                        marginBottom: "4px",
+                                        borderRadius: "10px",
+                                        backgroundColor: "#EEF2FF",
+                                        boxShadow: "0 2px 8px rgba(79,70,229,0.15)",
+                                        transition: "box-shadow 0.2s"
+                                    }}
+                                        onMouseOver={(e) => e.currentTarget.style.boxShadow = "0 4px 12px rgba(79,70,229,0.25)"}
+                                        onMouseOut={(e) => e.currentTarget.style.boxShadow = "0 2px 8px rgba(79,70,229,0.15)"}
+                                    >
+                                        <div style={{ fontWeight: 700, fontSize: "1rem", color: "#1a1a2e", marginBottom: "4px" }}>
+                                            {user?.name}
+                                        </div>
+                                        <div style={{ fontSize: "0.8rem", color: "#6366f1" }}>
+                                            {user?.email}
+                                        </div>
+                                    </div>
+
+                                    <div style={{ height: "8px" }} />
+
+                                    {/* Profile */}
+                                    <div
+                                        onClick={() => navigate("/profile")}
+                                        style={{ padding: "12px", cursor: "pointer", fontSize: "0.875rem", display: "flex", alignItems: "center", gap: "12px", borderRadius: "8px", color: "#444" }}
+                                        onMouseOver={(e) => {
+                                            e.currentTarget.style.backgroundColor = "#f5f5f5";
+                                            e.currentTarget.style.color = "#4F46E5";
+                                            e.currentTarget.querySelector("svg").style.stroke = "#4F46E5";
+                                        }}
+                                        onMouseOut={(e) => {
+                                            e.currentTarget.style.backgroundColor = "transparent";
+                                            e.currentTarget.style.color = "#444";
+                                            e.currentTarget.querySelector("svg").style.stroke = "#555";
+                                        }}
+                                    >
+                                        <User size={17} color="#555" /> Profile
+                                    </div>
+
+                                    {/* Settings */}
+                                    <div
+                                        onClick={() => navigate("/settings")}
+                                        style={{ padding: "12px", cursor: "pointer", fontSize: "0.875rem", display: "flex", alignItems: "center", gap: "12px", borderRadius: "8px", color: "#444" }}
+                                        onMouseOver={(e) => {
+                                            e.currentTarget.style.backgroundColor = "#f5f5f5";
+                                            e.currentTarget.style.color = "#4F46E5";
+                                            e.currentTarget.querySelector("svg").style.stroke = "#4F46E5";
+                                        }}
+                                        onMouseOut={(e) => {
+                                            e.currentTarget.style.backgroundColor = "transparent";
+                                            e.currentTarget.style.color = "#444";
+                                            e.currentTarget.querySelector("svg").style.stroke = "#555";
+                                        }}
+                                    >
+                                        <Settings size={17} color="#555" /> Settings
+                                    </div>
+
+                                    <div style={{ height: "1px", backgroundColor: "#f0f0f0", margin: "6px 0" }} />
+
+                                    {/* Logout */}
+                                    <div
+                                        onClick={async () => {
+                                            try {
+                                                await fetch("http://localhost:8000/api/v1/auth/logout", {
+                                                    method: "POST",
+                                                    headers: { Authorization: `Bearer ${getToken()}` }
+                                                });
+                                            } catch (e) {}
+                                            clearToken();
+                                            navigate("/login");
+                                        }}
+                                        style={{ padding: "12px", cursor: "pointer", fontSize: "0.875rem", color: "#dc2626", display: "flex", alignItems: "center", gap: "12px", borderRadius: "8px" }}
+                                        onMouseOver={(e) => {
+                                            e.currentTarget.style.backgroundColor = "#fee2e2";
+                                            e.currentTarget.style.color = "#991b1b";
+                                            e.currentTarget.style.fontWeight = "600";
+                                        }}
+                                        onMouseOut={(e) => {
+                                            e.currentTarget.style.backgroundColor = "transparent";
+                                            e.currentTarget.style.color = "#dc2626";
+                                            e.currentTarget.style.fontWeight = "normal";
+                                        }}
+                                    >
+                                        <LogOut size={17} /> Logout
+                                    </div>
+                                </div>
+                            )}
                         </div>
-                    </div>
                 </div>
 
+                {/* Page Content */}
                 <div style={{ flexGrow: 1, overflow: "auto", padding: "32px" }}>
                     <div style={{ marginBottom: "32px" }}>
                         <h1 style={{ fontSize: "2rem", fontWeight: 700, margin: "0 0 8px 0" }}>
@@ -354,9 +394,9 @@ export default function Dashboard() {
                         <p style={{ fontSize: "0.95rem", color: "#666", margin: "0 0 16px 0" }}>
                             {user?.email}
                         </p>
-                        <div style={{ 
-                            padding: "16px", 
-                            backgroundColor: "#f0f9ff", 
+                        <div style={{
+                            padding: "16px",
+                            backgroundColor: "#f0f9ff",
                             borderRadius: "8px",
                             border: "1px solid #bfdbfe",
                             display: "flex",
@@ -379,23 +419,26 @@ export default function Dashboard() {
                         </div>
                     </div>
 
-                        {loading ? (
-                            <div style={{ textAlign: "center", padding: "40px", color: "#666" }}>
-                                Loading files...
-                            </div>
-                        ) : filesError ? (
-                            <div style={{ textAlign: "center", padding: "40px", color: "#666" }}>
-                                <AlertTriangle size={32} color="#f59e0b" style={{ marginBottom: "8px" }} />
-                                <p style={{ fontSize: "0.875rem" }}>Something went wrong loading your files. Please try again.</p>
-                                <button onClick={() => { setFilesError(false); loadFiles(); }} style={{ marginTop: "8px", padding: "8px 16px", borderRadius: "8px", border: "1px solid #e0e0e0", cursor: "pointer", backgroundColor: "white" }}>
-                                    Retry
-                                </button>
-                            </div>
-                        ) : files.length === 0 ? (
-                            <div style={{ textAlign: "center", padding: "40px", color: "#666" }}>
-                                No files yet. Upload your first file!
-                            </div>
-                        ) : (
+                    {loading ? (
+                        <div style={{ textAlign: "center", padding: "40px", color: "#666" }}>
+                            Loading files...
+                        </div>
+                    ) : filesError ? (
+                        <div style={{ textAlign: "center", padding: "40px", color: "#666" }}>
+                            <AlertTriangle size={32} color="#f59e0b" style={{ marginBottom: "8px" }} />
+                            <p style={{ fontSize: "0.875rem" }}>Something went wrong loading your files. Please try again.</p>
+                            <button
+                                onClick={() => { setFilesError(false); loadFiles(); }}
+                                style={{ marginTop: "8px", padding: "8px 16px", borderRadius: "8px", border: "1px solid #e0e0e0", cursor: "pointer", backgroundColor: "white" }}
+                            >
+                                Retry
+                            </button>
+                        </div>
+                    ) : files.length === 0 ? (
+                        <div style={{ textAlign: "center", padding: "40px", color: "#666" }}>
+                            No files yet. Upload your first file!
+                        </div>
+                    ) : (
                         <>
                             <div style={{ marginBottom: "32px" }}>
                                 <h2 style={{ fontSize: "0.75rem", fontWeight: 600, color: "#999", margin: "0 0 16px 0", letterSpacing: "0.5px" }}>
@@ -418,28 +461,12 @@ export default function Dashboard() {
                                             onMouseOut={(e) => e.currentTarget.style.boxShadow = "0 1px 3px rgba(0,0,0,0.1)"}
                                         >
                                             <div style={{ display: "flex", alignItems: "center", marginBottom: "8px" }}>
-                                                {file.isFolder ? 
-                                                    <Folder size={24} color="#FFA726" /> : 
-                                                    <FileText size={24} color="#666" />
-                                                }
-                                                <button style={{
-                                                    marginLeft: "auto",
-                                                    border: "none",
-                                                    backgroundColor: "transparent",
-                                                    cursor: "pointer",
-                                                    padding: "4px"
-                                                }}>
+                                                {file.isFolder ? <Folder size={24} color="#FFA726" /> : <FileText size={24} color="#666" />}
+                                                <button style={{ marginLeft: "auto", border: "none", backgroundColor: "transparent", cursor: "pointer", padding: "4px" }}>
                                                     <MoreVertical size={16} color="#999" />
                                                 </button>
                                             </div>
-                                            <p style={{
-                                                fontSize: "0.875rem",
-                                                fontWeight: 500,
-                                                margin: "0 0 4px 0",
-                                                overflow: "hidden",
-                                                textOverflow: "ellipsis",
-                                                whiteSpace: "nowrap"
-                                            }}>
+                                            <p style={{ fontSize: "0.875rem", fontWeight: 500, margin: "0 0 4px 0", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                                                 {file.name}
                                             </p>
                                             <p style={{ fontSize: "0.75rem", color: "#999", margin: 0 }}>
@@ -466,7 +493,7 @@ export default function Dashboard() {
                                         <span style={{ fontSize: "0.75rem", fontWeight: 600, color: "#999" }}>TYPE</span>
                                         <span style={{ fontSize: "0.75rem", fontWeight: 600, color: "#999" }}>MODIFIED</span>
                                         <span style={{ fontSize: "0.75rem", fontWeight: 600, color: "#999" }}>SIZE</span>
-                                    </div>y
+                                    </div>
                                     {files.map((file, index) => (
                                         <div
                                             key={file.id}
@@ -482,24 +509,15 @@ export default function Dashboard() {
                                             onMouseOut={(e) => e.currentTarget.style.backgroundColor = "transparent"}
                                         >
                                             <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
-                                                {file.isFolder ? 
-                                                    <Folder size={20} color="#FFA726" /> : 
-                                                    <FileText size={20} color="#666" />
-                                                }
+                                                {file.isFolder ? <Folder size={20} color="#FFA726" /> : <FileText size={20} color="#666" />}
                                                 <span style={{ fontSize: "0.875rem", fontWeight: 500 }}>{file.name}</span>
                                             </div>
                                             <span style={{ fontSize: "0.875rem", color: "#666" }}>{file.type}</span>
                                             <span style={{ fontSize: "0.875rem", color: "#666" }}>{file.modified}</span>
                                             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
                                                 <span style={{ fontSize: "0.875rem", color: "#666" }}>{file.size}</span>
-                                                <button 
-                                                    style={{
-                                                        border: "none",
-                                                        backgroundColor: "transparent",
-                                                        cursor: "pointer",
-                                                        padding: "4px",
-                                                        position: "relative"
-                                                    }}
+                                                <button
+                                                    style={{ border: "none", backgroundColor: "transparent", cursor: "pointer", padding: "4px", position: "relative" }}
                                                     onClick={() => setActiveMenu(activeMenu === file.id ? null : file.id)}
                                                 >
                                                     <MoreVertical size={16} color="#999" />
@@ -515,63 +533,30 @@ export default function Dashboard() {
                                                             minWidth: "160px",
                                                             zIndex: 10
                                                         }}>
-                                                            <div style={{
-                                                                padding: "8px 16px",
-                                                                cursor: "pointer",
-                                                                display: "flex",
-                                                                alignItems: "center",
-                                                                gap: "12px",
-                                                                fontSize: "0.875rem"
-                                                            }}
-                                                            onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#f5f5f5"}
-                                                            onMouseOut={(e) => e.currentTarget.style.backgroundColor = "transparent"}
+                                                            <div style={{ padding: "8px 16px", cursor: "pointer", display: "flex", alignItems: "center", gap: "12px", fontSize: "0.875rem" }}
+                                                                onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#f5f5f5"}
+                                                                onMouseOut={(e) => e.currentTarget.style.backgroundColor = "transparent"}
                                                             >
-                                                                <Download size={16} />
-                                                                Download
+                                                                <Download size={16} /> Download
                                                             </div>
-                                                            <div style={{
-                                                                padding: "8px 16px",
-                                                                cursor: "pointer",
-                                                                display: "flex",
-                                                                alignItems: "center",
-                                                                gap: "12px",
-                                                                fontSize: "0.875rem"
-                                                            }}
-                                                            onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#f5f5f5"}
-                                                            onMouseOut={(e) => e.currentTarget.style.backgroundColor = "transparent"}
+                                                            <div style={{ padding: "8px 16px", cursor: "pointer", display: "flex", alignItems: "center", gap: "12px", fontSize: "0.875rem" }}
+                                                                onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#f5f5f5"}
+                                                                onMouseOut={(e) => e.currentTarget.style.backgroundColor = "transparent"}
                                                             >
-                                                                <Share2 size={16} />
-                                                                Share
+                                                                <Share2 size={16} /> Share
                                                             </div>
-                                                            <div style={{
-                                                                padding: "8px 16px",
-                                                                cursor: "pointer",
-                                                                display: "flex",
-                                                                alignItems: "center",
-                                                                gap: "12px",
-                                                                fontSize: "0.875rem"
-                                                            }}
-                                                            onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#f5f5f5"}
-                                                            onMouseOut={(e) => e.currentTarget.style.backgroundColor = "transparent"}
+                                                            <div style={{ padding: "8px 16px", cursor: "pointer", display: "flex", alignItems: "center", gap: "12px", fontSize: "0.875rem" }}
+                                                                onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#f5f5f5"}
+                                                                onMouseOut={(e) => e.currentTarget.style.backgroundColor = "transparent"}
                                                             >
-                                                                <Star size={16} />
-                                                                Add to Starred
+                                                                <Star size={16} /> Add to Starred
                                                             </div>
                                                             <div style={{ height: "1px", backgroundColor: "#e0e0e0", margin: "4px 0" }} />
-                                                            <div style={{
-                                                                padding: "8px 16px",
-                                                                cursor: "pointer",
-                                                                display: "flex",
-                                                                alignItems: "center",
-                                                                gap: "12px",
-                                                                fontSize: "0.875rem",
-                                                                color: "#dc2626"
-                                                            }}
-                                                            onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#fee2e2"}
-                                                            onMouseOut={(e) => e.currentTarget.style.backgroundColor = "transparent"}
+                                                            <div style={{ padding: "8px 16px", cursor: "pointer", display: "flex", alignItems: "center", gap: "12px", fontSize: "0.875rem", color: "#dc2626" }}
+                                                                onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#fee2e2"}
+                                                                onMouseOut={(e) => e.currentTarget.style.backgroundColor = "transparent"}
                                                             >
-                                                                <Trash2 size={16} />
-                                                                Delete
+                                                                <Trash2 size={16} /> Delete
                                                             </div>
                                                         </div>
                                                     )}


### PR DESCRIPTION
Closed issue #10

- Added clickable account circle in top bar that opens a dropdown menu
- Dropdown shows user's name and email
- Profile and Settings options navigate to their respective pages
- Logout calls the backend /auth/logout endpoint, clears token, and redirects to login
- Removed duplicate settings icon from top bar