### PR TITLE
fix: pin eslint back to v9 to resolve react-hooks plugin compatibility

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
-    "eslint": "^10.0.2",
+    "eslint": "^9.0.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",


### PR DESCRIPTION
Closes #25 

Dependabot bumped eslint to v10 but eslint-plugin-react-hooks@7.0.1 only supports up to eslint v9, breaking the build.

Fixed by pinning eslint back to ^9.0.0 in package.json.