### PR TITLE
Fix: Brand logo margins and readme file import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <center>
-   <img src="./frontend/public/secure_drive.svg" width="280" alt="Secure Drive Logo" />
+   <img src="./frontend/public/favicon.svg" width="280" alt="Secure Drive Logo" />
 </center>
+<br><br><br>
 
 # Secure Drive
 

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,38 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="100 120 290 330" role="img" aria-labelledby="title">
+<!DOCTYPE svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img"
+    aria-labelledby="title">
     <title id="title">Secure Drive icon</title>
 
     <defs>
         <linearGradient id="shield" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0" stop-color="#23D5FF"/>
-            <stop offset="1" stop-color="#2B6BFF"/>
+            <stop offset="0" stop-color="#23D5FF" />
+            <stop offset="1" stop-color="#2B6BFF" />
         </linearGradient>
 
         <linearGradient id="cloud" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0" stop-color="#EAF6FF"/>
-            <stop offset="1" stop-color="#BFE7FF"/>
+            <stop offset="0" stop-color="#EAF6FF" />
+            <stop offset="1" stop-color="#BFE7FF" />
         </linearGradient>
-
-        <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-            <feDropShadow dx="0" dy="10" stdDeviation="14" flood-color="#000" flood-opacity="0.35"/>
-        </filter>
     </defs>
 
-    <path fill="url(#shield)" filter="url(#shadow)" d="M256 110s80 32 116 46v102c0 74-53 122-116 144-63-22-116-70-116-144V156c36-14 116-46 116-46z"/>
+    <g transform="translate(-185 -185) scale(1.72)">
 
-    <path fill="#06182C" opacity="0.3" d="M256 142s63 25 90 36v78c0 56-41 94-90 112-49-18-90-56-90-112v-78c27-11 90-36 90-36z"/>
+        <path fill="url(#shield)"
+            d="M256 110s80 32 116 46v102c0 74-53 122-116 144-63-22-116-70-116-144V156c36-14 116-46 116-46z" />
 
-    <path fill="url(#cloud)" transform="translate(0 -20)" d="M208 250c2-19 18-34 38-34 15 0 28 8 35 21 4-2 9-3 14-3 17 0 31 13 31 30 0 18-14 32-32 32h-80c-17 0-30-13-30-29 0-13 10-24 24-17z"/>
+        <path fill="#06182C" opacity="0.3"
+            d="M256 142s63 25 90 36v78c0 56-41 94-90 112-49-18-90-56-90-112v-78c27-11 90-36 90-36z" />
 
-    <g transform="translate(145 161) scale(0.40)">
-        <path fill="none" stroke="#0B1220" stroke-width="25" stroke-linecap="round" stroke-linejoin="round" d="M228 269
-            v-18
-            c0-26.5 21.5-48 48-48
-            s48 21.5 48 48
-            v18"/>
+        <path fill="url(#cloud)" transform="translate(0 -20)"
+            d="M208 250c2-19 18-34 38-34 15 0 28 8 35 21 4-2 9-3 14-3 17 0 31 13 31 30 0 18-14 32-32 32h-80c-17 0-30-13-30-29 0-13 10-24 24-17z" />
+
+        <g transform="translate(145 161) scale(0.40)">
+            <path fill="none" stroke="#0B1220" stroke-width="25" stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M228 269
+         v-18
+         c0-26.5 21.5-48 48-48
+         s48 21.5 48 48
+         v18" />
+        </g>
+
+        <rect x="226" y="268" width="60" height="54" rx="12" fill="#0B1220" />
+
+        <circle cx="256" cy="285" r="6" fill="#BFE7FF" />
+        <path d="M256 310v15" transform="translate(0 -25)" stroke="#BFE7FF" stroke-width="3.5"
+            stroke-linecap="round" />
     </g>
-
-    <rect x="226" y="268" width="60" height="54" rx="12" fill="#0B1220"/>
-
-    <circle cx="256" cy="285" r="6" fill="#BFE7FF"/>
-    <path d="M256 310v15" transform="translate(0 -25)" stroke="#BFE7FF" stroke-width="3.5" stroke-linecap="round"/>
 </svg>

--- a/frontend/src/assets/logo.svg
+++ b/frontend/src/assets/logo.svg
@@ -1,38 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="60 90 392 390" role="img" aria-labelledby="title">
-  <title id="title">Secure Drive icon</title>
+<!DOCTYPE svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img"
+    aria-labelledby="title">
+    <title id="title">Secure Drive icon</title>
 
-  <defs>
-    <linearGradient id="shield" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#23D5FF"/>
-      <stop offset="1" stop-color="#2B6BFF"/>
-    </linearGradient>
+    <defs>
+        <linearGradient id="shield" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stop-color="#23D5FF" />
+            <stop offset="1" stop-color="#2B6BFF" />
+        </linearGradient>
 
-    <linearGradient id="cloud" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#EAF6FF"/>
-      <stop offset="1" stop-color="#BFE7FF"/>
-    </linearGradient>
+        <linearGradient id="cloud" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stop-color="#EAF6FF" />
+            <stop offset="1" stop-color="#BFE7FF" />
+        </linearGradient>
+    </defs>
 
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="10" stdDeviation="14" flood-color="#000" flood-opacity="0.35"/>
-    </filter>
-  </defs>
+    <g transform="translate(-185 -185) scale(1.72)">
 
-  <path fill="url(#shield)" filter="url(#shadow)" d="M256 110s80 32 116 46v102c0 74-53 122-116 144-63-22-116-70-116-144V156c36-14 116-46 116-46z"/>
+        <path fill="url(#shield)"
+            d="M256 110s80 32 116 46v102c0 74-53 122-116 144-63-22-116-70-116-144V156c36-14 116-46 116-46z" />
 
-  <path fill="#06182C" opacity="0.3" d="M256 142s63 25 90 36v78c0 56-41 94-90 112-49-18-90-56-90-112v-78c27-11 90-36 90-36z"/>
+        <path fill="#06182C" opacity="0.3"
+            d="M256 142s63 25 90 36v78c0 56-41 94-90 112-49-18-90-56-90-112v-78c27-11 90-36 90-36z" />
 
-  <path fill="url(#cloud)" transform="translate(0 -20)" d="M208 250c2-19 18-34 38-34 15 0 28 8 35 21 4-2 9-3 14-3 17 0 31 13 31 30 0 18-14 32-32 32h-80c-17 0-30-13-30-29 0-13 10-24 24-17z"/>
+        <path fill="url(#cloud)" transform="translate(0 -20)"
+            d="M208 250c2-19 18-34 38-34 15 0 28 8 35 21 4-2 9-3 14-3 17 0 31 13 31 30 0 18-14 32-32 32h-80c-17 0-30-13-30-29 0-13 10-24 24-17z" />
 
-  <g transform="translate(145 161) scale(0.40)">
-      <path fill="none" stroke="#0B1220" stroke-width="25" stroke-linecap="round" stroke-linejoin="round" d="M228 269
-          v-18
-          c0-26.5 21.5-48 48-48
-          s48 21.5 48 48
-          v18"/>
-  </g>
+        <g transform="translate(145 161) scale(0.40)">
+            <path fill="none" stroke="#0B1220" stroke-width="25" stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M228 269
+         v-18
+         c0-26.5 21.5-48 48-48
+         s48 21.5 48 48
+         v18" />
+        </g>
 
-  <rect x="226" y="268" width="60" height="54" rx="12" fill="#0B1220"/>
+        <rect x="226" y="268" width="60" height="54" rx="12" fill="#0B1220" />
 
-  <circle cx="256" cy="285" r="6" fill="#BFE7FF"/>
-  <path d="M256 310v15" transform="translate(0 -25)" stroke="#BFE7FF" stroke-width="3.5" stroke-linecap="round"/>
+        <circle cx="256" cy="285" r="6" fill="#BFE7FF" />
+        <path d="M256 310v15" transform="translate(0 -25)" stroke="#BFE7FF" stroke-width="3.5"
+            stroke-linecap="round" />
+    </g>
 </svg>


### PR DESCRIPTION
Remove extra margin around brand logo, and center the body. And change the README file to point to the new logo.