### PR TITLE
Fix: Fix the email verification link through cloudflare tunnel #2

### DIFF
--- a/api/app/services/mailer/_mailer.py
+++ b/api/app/services/mailer/_mailer.py
@@ -4,22 +4,20 @@ import os
 import re
 import smtplib
 import socket
-from pathlib import Path
-from functools import lru_cache
 from dataclasses import dataclass
-from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 from email.utils import formataddr, parseaddr
-from urllib.parse import quote
+from functools import lru_cache
+from pathlib import Path
 
 from .exceptions import (
+    InvalidAddressError,
     MailerError,
     SMTPAuthenticationError,
     SMTPConnectionError,
     SMTPSendError,
-    InvalidAddressError
 )
-
 
 # ---------------------------------------------------------------------------
 # Config dataclass
@@ -209,7 +207,7 @@ def send_verification_email(
     sender_addr = _validate_address(config.SMTP_ADDRESS, "sender")
     recipient_addr = _validate_address(recipient, "recipient")
 
-    verify_url = f"{config.ENDPOINT}/{quote(signed_token, safe='')}"
+    verify_url = f"{config.ENDPOINT}/{signed_token}"
 
     text_body = config.TEXT_BODY_TEMPLATE.replace(
         config.URL_PLACEHOLDER, verify_url

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -63,7 +63,7 @@ services:
     env_file:
       - .env.dev
     environment:
-      - VITE_API_URL=http://localhost:${API_PORT:-8000}
+      - VITE_API_URL=http://api:8000
       - CHOKIDAR_USEPOLLING=true
       - CHOKIDAR_INTERVAL=1000 
     command: npm run dev -- --host 0.0.0.0

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,17 +1,25 @@
-import { defineConfig, loadEnv } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig, loadEnv } from "vite";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  const env = loadEnv(mode, process.cwd(), "");
 
   return {
     plugins: [react()],
 
-    // Source - https://stackoverflow.com/a/79377387
-    // Posted by ansmonjol, modified by community. See post 'Timeline' for change history
-    // Retrieved 2026-03-02, License - CC BY-SA 4.0
     server: {
       allowedHosts: [env.VITE_DOMAIN],
+      proxy: {
+        "/api": {
+          target: env.VITE_API_URL || "http://localhost:8000",
+          changeOrigin: true,
+        },
+      },
+      hmr: {
+        host: env.VITE_DOMAIN,
+        protocol: "wss", // cloudflare tunnel is always HTTPS/WSS
+        clientPort: 443, // tunnel terminates SSL, so client connects on 443
+      },
     },
-  }
-})
+  };
+});


### PR DESCRIPTION
change vite proxy settings to point to the api url, and defined the api url properly in the compose yml file. Also remove the redundant "quote" function call in the mailer service, the signed token is already url safe.

The reason it was not working in the first place is cloudflared tunneling was pointing to the vite app at `5173`, where the verification link was assuming cloudflared points to the backend api at `8000`. Issue fixed in development with a simple vite proxy setup. And a reverse proxy using nginx is planned to fix this issue in production.