### PR TITLE
Feat: show verification success notice on login page

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -4,6 +4,7 @@ import { Visibility, VisibilityOff } from "@mui/icons-material";
 import { useNavigate } from "react-router-dom";
 import Logo from "../assets/logo.svg";
 import { setToken } from "../tokenStore";
+import { useSearchParams } from "react-router-dom";
 
 function Login() {
     const navigate = useNavigate();
@@ -14,6 +15,8 @@ function Login() {
     const [error, setError] = useState("");
     const [loading, setLoading] = useState(false);
     const [showPassword, setShowPassword] = useState(false);
+    const [searchParams] = useSearchParams();
+    const justVerified = searchParams.get("verified") === "true";
 
     const handleChange = (e) => {
         setFormData({
@@ -107,6 +110,11 @@ function Login() {
             {error && (
                 <Alert severity="error" sx={{ mb: 2 }}>
                     {error}
+                </Alert>
+            )}
+            {justVerified && (
+                <Alert severity="success" sx={{ mb: 2 }}>
+                    Email verified successfully! You can now log in.
                 </Alert>
             )}
 


### PR DESCRIPTION
## Summary
Shows a success banner on the login page when a user arrives 
after verifying their email.

## Changes
- Added `justVerified` flag that reads `?verified=true` from the URL
- Shows success alert when flag is present

## Note
Requires backend to update the verify_email redirect in auth.py 
to point to `{BASE_URL}/login?verified=true` instead of hardcoded localhost.

Closes #46 