### PR TITLE
feat(frontend): centralize API client and prepare dual-service routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ SMTP_ADDRESS=your-email@gmail.com                                   # Email addr
 SMTP_USERNAME=your-email-or-userid@gmail.com                        # SMTP username (usually your email address, used for authentication)
 SMTP_PASSWORD="your app specific password"                          # SMTP password (use an app-specific password if using Gmail with 2FA)
 SMTP_SECURITY=tls                                                   # SMTP security protocol (tls or ssl)
-             
+
 # JWT Configuration          
 JWT_SECRET_KEY=A-random-32-bytes-string                             # Secret key for signing JWT tokens
 ACCESS_TOKEN_TTL_SECONDS=900                                        # Access token time to live in seconds. 900 seconds is 15 minutes

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -64,6 +64,7 @@ services:
       - .env.dev
     environment:
       - VITE_API_URL=http://api:8000
+      - VITE_AUTH_URL=http://auth:8001
       - CHOKIDAR_USEPOLLING=true
       - CHOKIDAR_INTERVAL=1000 
     command: npm run dev -- --host 0.0.0.0

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,10 @@
 import { getToken, clearToken, getRefreshToken, setToken } from "./tokenStore";
 
-const API_BASE_URL = '/api/v1';
+// Relative paths — Vite proxy handles routing to the right service
+// /auth-api/* → auth service (port 8001)
+// /api/*      → core service (port 8000)
+const AUTH_BASE = '/auth-api/api/v1';
+const CORE_BASE = '/api/v1';
 
 let _isRefreshing = false;
 let _failedQueue = [];
@@ -32,7 +36,6 @@ async function handleResponse(response, retryFn = null) {
         }
 
         if (_isRefreshing) {
-            // Another request is already refreshing, queue this one
             return new Promise((resolve, reject) => {
                 _failedQueue.push({ resolve, reject });
             }).then((token) => {
@@ -43,7 +46,7 @@ async function handleResponse(response, retryFn = null) {
         _isRefreshing = true;
 
         try {
-            const res = await fetch(`${API_BASE_URL}/auth/refresh`, {
+            const res = await fetch(`${AUTH_BASE}/auth/refresh`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ refresh_token: refreshToken }),
@@ -63,8 +66,6 @@ async function handleResponse(response, retryFn = null) {
                 setRefreshToken(data.refresh_token);
             }
             processQueue(null, data.access_token);
-
-            // Retry the original request
             if (retryFn) return retryFn(data.access_token);
 
         } catch (err) {
@@ -93,21 +94,91 @@ async function handleResponse(response, retryFn = null) {
 }
 
 export const api = {
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    async login(email, password) {
+        const response = await fetch(`${AUTH_BASE}/auth/login`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email, password }),
+        });
+        return handleResponse(response);
+    },
+
+    async register(name, email, password) {
+        const response = await fetch(`${AUTH_BASE}/auth/register`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name, email, password }),
+        });
+        return handleResponse(response);
+    },
+
+    async resendVerification(email) {
+        const response = await fetch(
+            `${AUTH_BASE}/auth/resend-verification?email=${encodeURIComponent(email)}`,
+            { method: "POST" }
+        );
+        return handleResponse(response);
+    },
+
+    async forgotPassword(email) {
+        const response = await fetch(
+            `${AUTH_BASE}/auth/forgot-password?email=${encodeURIComponent(email)}`,
+            { method: "POST" }
+        );
+        return handleResponse(response);
+    },
+
+    async validateResetToken(token) {
+        const response = await fetch(`${AUTH_BASE}/auth/reset-password/${token}`);
+        return handleResponse(response);
+    },
+
+    async resetPassword(email, newPassword) {
+        const response = await fetch(`${AUTH_BASE}/auth/reset-password`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email, new_password: newPassword }),
+        });
+        return handleResponse(response);
+    },
+
     async getMe() {
-        const response = await fetch(`${API_BASE_URL}/auth/me`, { headers: authHeaders() });
+        const response = await fetch(`${AUTH_BASE}/auth/me`, { headers: authHeaders() });
         return handleResponse(response, (token) =>
-            fetch(`${API_BASE_URL}/auth/me`, { headers: { Authorization: `Bearer ${token}` } }).then(r => r.json())
+            fetch(`${AUTH_BASE}/auth/me`, { headers: { Authorization: `Bearer ${token}` } }).then(r => r.json())
         );
     },
 
+    async updateName(name) {
+        const response = await fetch(`${AUTH_BASE}/auth/me`, {
+            method: "PATCH",
+            headers: authHeaders({ "Content-Type": "application/json" }),
+            body: JSON.stringify({ name }),
+        });
+        return handleResponse(response);
+    },
+
+    async changePassword(currentPassword, newPassword) {
+        const response = await fetch(`${AUTH_BASE}/auth/me/password`, {
+            method: "PATCH",
+            headers: authHeaders({ "Content-Type": "application/json" }),
+            body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+        });
+        return handleResponse(response);
+    },
+
     async logout() {
-        const response = await fetch(`${API_BASE_URL}/auth/logout`, {
+        const response = await fetch(`${AUTH_BASE}/auth/logout`, {
             method: "POST",
             headers: authHeaders(),
         });
         if (response.status === 401 || response.ok) return;
         return handleResponse(response);
     },
+
+    // ── Files ─────────────────────────────────────────────────────────────────
 
     async getFiles(params = {}) {
         const queryParams = new URLSearchParams();
@@ -118,16 +189,16 @@ export const api = {
         if (params.limit) queryParams.append('limit', params.limit);
         if (params.offset) queryParams.append('offset', params.offset);
 
-        const response = await fetch(`${API_BASE_URL}/files?${queryParams}`, { headers: authHeaders() });
+        const response = await fetch(`${CORE_BASE}/files?${queryParams}`, { headers: authHeaders() });
         return handleResponse(response, (token) =>
-            fetch(`${API_BASE_URL}/files?${queryParams}`, { headers: { Authorization: `Bearer ${token}` } }).then(r => r.json())
+            fetch(`${CORE_BASE}/files?${queryParams}`, { headers: { Authorization: `Bearer ${token}` } }).then(r => r.json())
         );
     },
 
     async getStorageStats() {
-        const response = await fetch(`${API_BASE_URL}/files/stats`, { headers: authHeaders() });
+        const response = await fetch(`${CORE_BASE}/files/stats`, { headers: authHeaders() });
         return handleResponse(response, (token) =>
-            fetch(`${API_BASE_URL}/files/stats`, { headers: { Authorization: `Bearer ${token}` } }).then(r => r.json())
+            fetch(`${CORE_BASE}/files/stats`, { headers: { Authorization: `Bearer ${token}` } }).then(r => r.json())
         );
     },
 
@@ -137,7 +208,7 @@ export const api = {
         if (folder) formData.append('folder', folder);
         if (logicalName) formData.append('logical_name', logicalName);
 
-        const response = await fetch(`${API_BASE_URL}/files`, {
+        const response = await fetch(`${CORE_BASE}/files`, {
             method: 'POST',
             headers: authHeaders(),
             body: formData,
@@ -146,7 +217,7 @@ export const api = {
     },
 
     async deleteFile(fileId) {
-        const response = await fetch(`${API_BASE_URL}/files/${fileId}`, {
+        const response = await fetch(`${CORE_BASE}/files/${fileId}`, {
             method: 'DELETE',
             headers: authHeaders(),
         });
@@ -154,6 +225,6 @@ export const api = {
     },
 
     getDownloadUrl(fileId) {
-        return `${API_BASE_URL}/files/${fileId}`;
+        return `${CORE_BASE}/files/${fileId}`;
     },
 };

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,17 +1,14 @@
 import { useState } from "react";
 import { Box, Card, TextField, Button, Typography, Alert, InputAdornment, IconButton } from "@mui/material";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import Logo from "../assets/logo.svg";
 import { setToken, setRefreshToken } from "../tokenStore";
-import { useSearchParams } from "react-router-dom";
+import { api } from "../api";
 
 function Login() {
     const navigate = useNavigate();
-    const [formData, setFormData] = useState({
-        email: "",
-        password: ""
-    });
+    const [formData, setFormData] = useState({ email: "", password: "" });
     const [error, setError] = useState("");
     const [loading, setLoading] = useState(false);
     const [showPassword, setShowPassword] = useState(false);
@@ -19,82 +16,44 @@ function Login() {
     const justVerified = searchParams.get("verified") === "true";
 
     const handleChange = (e) => {
-        setFormData({
-            ...formData,
-            [e.target.name]: e.target.value
-        });
+        setFormData({ ...formData, [e.target.name]: e.target.value });
     };
 
     const handleLogin = async () => {
         setError("");
 
-        // Validation
         if (!formData.email || !formData.password) {
             setError("Please enter both email and password");
             return;
         }
-
         if (formData.password.length < 8) {
             setError("Password must be at least 8 characters.");
             return;
         }
-
         if (formData.password.length > 128) {
             setError("Password is too long.");
             return;
         }
 
         setLoading(true);
-
         try {
-            const response = await fetch("/api/v1/auth/login", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    email: formData.email,
-                    password: formData.password
-                }),
-            });
-
-            const data = await response.json();
-
-            if (response.ok) {
-                setToken(data.access_token);
-                setRefreshToken(data.refresh_token);
-                navigate("/dashboard");
-            } else if (response.status === 422) {
-                setError("Invalid email or password format. Please check your input.");
-            } else if (response.status === 500) {
-                setError("Something went wrong on our end. Please try again later.");
-            } else {
-                setError(data.detail || "Login failed. Please check your credentials.");
-            }
-        } catch {
-            setError("Network error. Please check your connection.");
+            const data = await api.login(formData.email, formData.password);
+            setToken(data.access_token);
+            setRefreshToken(data.refresh_token);
+            navigate("/dashboard");
+        } catch (err) {
+            setError(err.message || "Login failed. Please check your credentials.");
         } finally {
             setLoading(false);
         }
     };
 
     const handleKeyPress = (e) => {
-        if (e.key === "Enter") {
-            handleLogin();
-        }
+        if (e.key === "Enter") handleLogin();
     };
 
     return (
-        <Card 
-            sx={{
-                width: 380, 
-                padding: 7, 
-                borderRadius: 3, 
-                backgroundColor: "#ffffff",
-                boxShadow: "0px 10px 40px rgba(0,0,0,0.3)", 
-                textAlign: "center"
-            }}>
-            {/* Title */}
+        <Card sx={{ width: 380, padding: 7, borderRadius: 3, backgroundColor: "#ffffff", boxShadow: "0px 10px 40px rgba(0,0,0,0.3)", textAlign: "center" }}>
             <Box display="flex" alignItems="center" flexDirection="column" mb={2}>
                 <img src={Logo} alt="Secure Drive logo" style={{ width: 150, height: 150, marginBottom: 6 }} />
                 <Typography variant="h3" fontWeight={700} lineHeight={1.1} sx={{ whiteSpace: "nowrap", fontSize: "1.8rem" }}>
@@ -107,57 +66,24 @@ function Login() {
                 </Typography>
             </Box>
 
-            {/* Error Message */}
-            {error && (
-                <Alert severity="error" sx={{ mb: 2 }}>
-                    {error}
-                </Alert>
-            )}
-            {justVerified && (
-                <Alert severity="success" sx={{ mb: 2 }}>
-                    Email verified successfully! You can now log in.
-                </Alert>
-            )}
+            {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+            {justVerified && <Alert severity="success" sx={{ mb: 2 }}>Email verified successfully! You can now log in.</Alert>}
 
-            {/* Email */}
             <Box mb={2} textAlign="left">
-                <Typography variant="body2" mb={0.5}>
-                    Email
-                </Typography>
-                <TextField 
-                    fullWidth 
-                    size="small" 
-                    placeholder="Enter your email"
-                    name="email"
-                    type="email"
-                    value={formData.email}
-                    onChange={handleChange}
-                    onKeyPress={handleKeyPress}
-                />
+                <Typography variant="body2" mb={0.5}>Email</Typography>
+                <TextField fullWidth size="small" placeholder="Enter your email" name="email" type="email"
+                    value={formData.email} onChange={handleChange} onKeyPress={handleKeyPress} />
             </Box>
 
-            {/* Password */}
             <Box mb={2} textAlign="left">
-                <Typography variant="body2" mb={0.5}>
-                    Password
-                </Typography>
-                <TextField 
-                    fullWidth 
-                    size="small" 
-                    type={showPassword ? "text" : "password"}
-                    placeholder="Enter your password"
-                    name="password"
-                    value={formData.password}
-                    onChange={handleChange}
-                    onKeyPress={handleKeyPress}
+                <Typography variant="body2" mb={0.5}>Password</Typography>
+                <TextField fullWidth size="small" type={showPassword ? "text" : "password"}
+                    placeholder="Enter your password" name="password"
+                    value={formData.password} onChange={handleChange} onKeyPress={handleKeyPress}
                     InputProps={{
                         endAdornment: (
                             <InputAdornment position="end">
-                                <IconButton
-                                    onClick={() => setShowPassword(!showPassword)}
-                                    edge="end"
-                                    size="small"
-                                >
+                                <IconButton onClick={() => setShowPassword(!showPassword)} edge="end" size="small">
                                     {showPassword ? <VisibilityOff /> : <Visibility />}
                                 </IconButton>
                             </InputAdornment>
@@ -166,42 +92,19 @@ function Login() {
                 />
             </Box>
 
-            {/* Forgot password */}
-            <Typography variant="body2" sx={{ 
-                textAlign: "right", 
-                mb: 2, 
-                cursor: "pointer",
-                color: "#666",
-                "&:hover": {
-                    color: "#4F46E5"
-                }
-            }}
-            onClick={() => navigate("/forgot-password")}>
+            <Typography variant="body2" sx={{ textAlign: "right", mb: 2, cursor: "pointer", color: "#666", "&:hover": { color: "#4F46E5" } }}
+                onClick={() => navigate("/forgot-password")}>
                 Forgot password?
             </Typography>
 
-            {/* Login button */}
-            <Button 
-                fullWidth 
-                variant="contained" 
-                onClick={handleLogin}
-                disabled={loading}
-                sx={{
-                    backgroundColor: "#4F46E5", 
-                    borderRadius: 2, 
-                    textTransform: "none", 
-                    fontWeight: 500, 
-                    py: 1, 
-                    mb: 2
-                }}>
+            <Button fullWidth variant="contained" onClick={handleLogin} disabled={loading}
+                sx={{ backgroundColor: "#4F46E5", borderRadius: 2, textTransform: "none", fontWeight: 500, py: 1, mb: 2 }}>
                 {loading ? "Logging in..." : "Login"}
             </Button>
 
             <Typography variant="body2">
                 Don't have an account?{" "}
-                <span style={{ color: "#4F46E5", cursor: "pointer" }} onClick={() => navigate("/signup")}>
-                    Sign up
-                </span>
+                <span style={{ color: "#4F46E5", cursor: "pointer" }} onClick={() => navigate("/signup")}>Sign up</span>
             </Typography>
         </Card>
     );

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Logo from "../assets/logo.svg";
 import { ArrowLeft, Key, HardDrive } from 'lucide-react';
-import { getToken, clearToken } from "../tokenStore";
+import { clearToken } from "../tokenStore";
 import { api } from "../api";
 
 export default function Profile() {
@@ -83,23 +83,10 @@ export default function Profile() {
         }
         setNameSaving(true);
         try {
-            const token = getToken();
-            const response = await fetch("/api/v1/auth/me", {
-                method: "PATCH",
-                headers: {
-                    "Authorization": `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ name: newName.trim() })
-            });
-            if (response.ok) {
-                const data = await response.json();
-                setUser(data);
-                setEditing(false);
-                showToast("Name updated successfully.");
-            } else {
-                showToast("Failed to update name. Please try again.", "error");
-            }
+            const data = await api.updateName(newName.trim());
+            setUser(data);
+            setEditing(false);
+            showToast("Name updated successfully.");
         } catch {
             showToast("Network error. Please try again.", "error");
         } finally {
@@ -133,26 +120,9 @@ export default function Profile() {
 
         setPasswordLoading(true);
         try {
-            const token = getToken();
-            const response = await fetch("/api/v1/auth/me/password", {
-                method: "PATCH",
-                headers: {
-                    "Authorization": `Bearer ${token}`,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({
-                    current_password: currentPassword,
-                    new_password: newPassword,
-                })
-            });
-            if (response.ok) {
-                showToast("Password changed successfully.");
-                setPasswordForm({ currentPassword: "", newPassword: "", confirmPassword: "" });
-            } else if (response.status === 401) {
-                showToast("Current password is incorrect.", "error");
-            } else {
-                showToast("Failed to change password. Please try again.", "error");
-            }
+            await api.changePassword(currentPassword, newPassword);
+            showToast("Password changed successfully.");
+            setPasswordForm({ currentPassword: "", newPassword: "", confirmPassword: "" });
         } catch {
             showToast("Network error. Please try again.", "error");
         } finally {

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -3,48 +3,36 @@ import { Box, Card, TextField, Button, Typography, Alert, LinearProgress, InputA
 import { useNavigate } from "react-router-dom";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
 import Logo from "../assets/logo.svg";
+import { api } from "../api";
 
 function Signup() {
     const navigate = useNavigate();
-    const [formData, setFormData] = useState({
-        name: "",
-        email: "",
-        password: "",
-        confirmPassword: ""
-    });
+    const [formData, setFormData] = useState({ name: "", email: "", password: "", confirmPassword: "" });
     const [error, setError] = useState("");
-    const [success, setSuccess] = useState("");
     const [loading, setLoading] = useState(false);
     const [showPassword, setShowPassword] = useState(false);
     const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
     const handleChange = (e) => {
-        setFormData({
-            ...formData,
-            [e.target.name]: e.target.value
-        });
+        setFormData({ ...formData, [e.target.name]: e.target.value });
     };
 
-    // Password strength calculation
     const calculatePasswordStrength = (password) => {
-        let strength = 0;
         const checks = {
             length: password.length >= 8,
             uppercase: /[A-Z]/.test(password),
             lowercase: /[a-z]/.test(password),
             number: /[0-9]/.test(password),
-            special: /[!@#$%^&*(),.?":{}|<>]/.test(password)
+            special: /[!@#$%^&*(),.?":{}|<>]/.test(password),
         };
-
-        strength = Object.values(checks).filter(Boolean).length;
-        return { strength, checks };
+        return { strength: Object.values(checks).filter(Boolean).length, checks };
     };
 
     const getPasswordStrengthColor = (strength) => {
-        if (strength <= 2) return "#ef4444"; // Red
-        if (strength === 3) return "#f59e0b"; // Orange
-        if (strength === 4) return "#eab308"; // Yellow
-        return "#22c55e"; // Green
+        if (strength <= 2) return "#ef4444";
+        if (strength === 3) return "#f59e0b";
+        if (strength === 4) return "#eab308";
+        return "#22c55e";
     };
 
     const getPasswordStrengthLabel = (strength) => {
@@ -54,184 +42,84 @@ function Signup() {
         return "Strong";
     };
 
-    const passwordStrength = calculatePasswordStrength(formData.password);
-    const strengthPercentage = (passwordStrength.strength / 5) * 100;
-
     const validatePassword = (password, email) => {
         const errors = [];
-
-        if (password.length < 8) {
-            errors.push("At least 8 characters");
-        }
-        if (!/[A-Z]/.test(password)) {
-            errors.push("At least one uppercase letter (A-Z)");
-        }
-        if (!/[a-z]/.test(password)) {
-            errors.push("At least one lowercase letter (a-z)");
-        }
-        if (!/[0-9]/.test(password)) {
-            errors.push("At least one number (0-9)");
-        }
-        if (!/[!@#$%^&*(),.?":{}|<>]/.test(password)) {
-            errors.push("At least one special character (!@#$%^&*)");
-        }
-
-        // Check if password contains email username
+        if (password.length < 8) errors.push("At least 8 characters");
+        if (!/[A-Z]/.test(password)) errors.push("At least one uppercase letter (A-Z)");
+        if (!/[a-z]/.test(password)) errors.push("At least one lowercase letter (a-z)");
+        if (!/[0-9]/.test(password)) errors.push("At least one number (0-9)");
+        if (!/[!@#$%^&*(),.?":{}|<>]/.test(password)) errors.push("At least one special character (!@#$%^&*)");
         if (email) {
             const emailUsername = email.split('@')[0].toLowerCase();
-            if (password.toLowerCase().includes(emailUsername)) {
-                errors.push("Password cannot contain your email address");
-            }
+            if (password.toLowerCase().includes(emailUsername)) errors.push("Password cannot contain your email address");
         }
-
         return errors;
     };
 
+    const passwordStrength = calculatePasswordStrength(formData.password);
+
     const handleSignup = async () => {
         setError("");
-        setSuccess("");
 
-        // Validation
         if (!formData.name || !formData.email || !formData.password) {
             setError("Please fill in all fields");
             return;
         }
-
-        // Email format validation
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (!emailRegex.test(formData.email)) {
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
             setError("Please enter a valid email address");
             return;
         }
-
-        // Password validation
         const passwordErrors = validatePassword(formData.password, formData.email);
         if (passwordErrors.length > 0) {
             setError("Password requirements:\n• " + passwordErrors.join("\n• "));
             return;
         }
-
         if (formData.password !== formData.confirmPassword) {
             setError("Passwords do not match");
             return;
         }
 
         setLoading(true);
-
         try {
-            const response = await fetch("/api/v1/auth/register", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    name: formData.name,
-                    email: formData.email,
-                    password: formData.password
-                }),
-            });
-
-            const data = await response.json();
-
-        if (response.ok) {
+            await api.register(formData.name, formData.email, formData.password);
             navigate("/verify-email", { state: { email: formData.email } });
-        } else {
-                setError(data.detail || "Signup failed. Please try again.");
-            }
         } catch (err) {
-            setError("Network error. Please check if the backend is running.");
+            setError(err.message || "Signup failed. Please try again.");
         } finally {
             setLoading(false);
         }
     };
 
     return (
-        <Card
-            sx={{
-                width: 420,
-                padding: 7,
-                borderRadius: 3,
-                backgroundColor: "#ffffff",
-                boxShadow: "0px 10px 40px rgba(0,0,0,0.3)",
-                textAlign: "center"
-            }}>
-            {/* Title */}
+        <Card sx={{ width: 420, padding: 7, borderRadius: 3, backgroundColor: "#ffffff", boxShadow: "0px 10px 40px rgba(0,0,0,0.3)", textAlign: "center" }}>
             <Box display="flex" alignItems="center" flexDirection="column" mb={2}>
                 <img src={Logo} alt="Secure Drive logo" style={{ width: 150, height: 150, marginBottom: 6 }} />
-                <Typography variant="h3" fontWeight={700} lineHeight={1.1} sx={{ fontSize: "1.8rem" }}>
-                    Secure Drive
-                </Typography>
+                <Typography variant="h3" fontWeight={700} lineHeight={1.1} sx={{ fontSize: "1.8rem" }}>Secure Drive</Typography>
             </Box>
             <Box display="flex" alignItems="center" flexDirection="column" mb={2}>
-                <Typography variant="h3" fontWeight={700} lineHeight={1.1} sx={{ fontSize: "1.3rem" }}>
-                    Create Account
-                </Typography>
+                <Typography variant="h3" fontWeight={700} lineHeight={1.1} sx={{ fontSize: "1.3rem" }}>Create Account</Typography>
             </Box>
 
-            {/* Error/Success Messages */}
-            {error && (
-                <Alert severity="error" sx={{ mb: 2, textAlign: "left", whiteSpace: "pre-line" }}>
-                    {error}
-                </Alert>
-            )}
-            {success && (
-                <Alert severity="success" sx={{ mb: 2 }}>
-                    {success}
-                </Alert>
-            )}
+            {error && <Alert severity="error" sx={{ mb: 2, textAlign: "left", whiteSpace: "pre-line" }}>{error}</Alert>}
 
-            {/* Name */}
             <Box mb={2} textAlign="left">
-                <Typography variant="body2" mb={0.5}>
-                    Name
-                </Typography>
-                <TextField 
-                    fullWidth 
-                    size="small" 
-                    placeholder="Enter your name"
-                    name="name"
-                    value={formData.name}
-                    onChange={handleChange}
-                />
+                <Typography variant="body2" mb={0.5}>Name</Typography>
+                <TextField fullWidth size="small" placeholder="Enter your name" name="name" value={formData.name} onChange={handleChange} />
             </Box>
 
-            {/* Email */}
             <Box mb={2} textAlign="left">
-                <Typography variant="body2" mb={0.5}>
-                    Email
-                </Typography>
-                <TextField 
-                    fullWidth 
-                    size="small" 
-                    placeholder="Enter your email"
-                    name="email"
-                    type="email"
-                    value={formData.email}
-                    onChange={handleChange}
-                />
+                <Typography variant="body2" mb={0.5}>Email</Typography>
+                <TextField fullWidth size="small" placeholder="Enter your email" name="email" type="email" value={formData.email} onChange={handleChange} />
             </Box>
 
-            {/* Password */}
             <Box mb={1} textAlign="left">
-                <Typography variant="body2" mb={0.5}>
-                    Password
-                </Typography>
-                <TextField 
-                    fullWidth 
-                    size="small" 
-                    type={showPassword ? "text" : "password"}
-                    placeholder="Create a password"
-                    name="password"
-                    value={formData.password}
-                    onChange={handleChange}
+                <Typography variant="body2" mb={0.5}>Password</Typography>
+                <TextField fullWidth size="small" type={showPassword ? "text" : "password"} placeholder="Create a password"
+                    name="password" value={formData.password} onChange={handleChange}
                     InputProps={{
                         endAdornment: (
                             <InputAdornment position="end">
-                                <IconButton
-                                    onClick={() => setShowPassword(!showPassword)}
-                                    edge="end"
-                                    size="small"
-                                >
+                                <IconButton onClick={() => setShowPassword(!showPassword)} edge="end" size="small">
                                     {showPassword ? <VisibilityOff /> : <Visibility />}
                                 </IconButton>
                             </InputAdornment>
@@ -240,87 +128,35 @@ function Signup() {
                 />
             </Box>
 
-            {/* Password Strength Meter */}
             {formData.password && (
                 <Box mb={2} textAlign="left">
                     <Box display="flex" justifyContent="space-between" alignItems="center" mb={0.5}>
-                        <Typography variant="caption" sx={{ color: "#666" }}>
-                            Password Strength
-                        </Typography>
-                        <Typography 
-                            variant="caption" 
-                            sx={{ 
-                                color: getPasswordStrengthColor(passwordStrength.strength),
-                                fontWeight: 600
-                            }}
-                        >
+                        <Typography variant="caption" sx={{ color: "#666" }}>Password Strength</Typography>
+                        <Typography variant="caption" sx={{ color: getPasswordStrengthColor(passwordStrength.strength), fontWeight: 600 }}>
                             {getPasswordStrengthLabel(passwordStrength.strength)}
                         </Typography>
                     </Box>
-                    <LinearProgress 
-                        variant="determinate" 
-                        value={strengthPercentage}
-                        sx={{
-                            height: 6,
-                            borderRadius: 3,
-                            backgroundColor: "#e5e7eb",
-                            "& .MuiLinearProgress-bar": {
-                                backgroundColor: getPasswordStrengthColor(passwordStrength.strength),
-                                borderRadius: 3
-                            }
-                        }}
+                    <LinearProgress variant="determinate" value={(passwordStrength.strength / 5) * 100}
+                        sx={{ height: 6, borderRadius: 3, backgroundColor: "#e5e7eb", "& .MuiLinearProgress-bar": { backgroundColor: getPasswordStrengthColor(passwordStrength.strength), borderRadius: 3 } }}
                     />
                     <Box mt={1}>
-                        {!passwordStrength.checks.length && (
-                            <Typography variant="caption" sx={{ color: "#666", display: "block" }}>
-                                • At least 8 characters
-                            </Typography>
-                        )}
-                        {!passwordStrength.checks.uppercase && (
-                            <Typography variant="caption" sx={{ color: "#666", display: "block" }}>
-                                • One uppercase letter
-                            </Typography>
-                        )}
-                        {!passwordStrength.checks.lowercase && (
-                            <Typography variant="caption" sx={{ color: "#666", display: "block" }}>
-                                • One lowercase letter
-                            </Typography>
-                        )}
-                        {!passwordStrength.checks.number && (
-                            <Typography variant="caption" sx={{ color: "#666", display: "block" }}>
-                                • One number
-                            </Typography>
-                        )}
-                        {!passwordStrength.checks.special && (
-                            <Typography variant="caption" sx={{ color: "#666", display: "block" }}>
-                                • One special character
-                            </Typography>
-                        )}
+                        {!passwordStrength.checks.length && <Typography variant="caption" sx={{ color: "#666", display: "block" }}>• At least 8 characters</Typography>}
+                        {!passwordStrength.checks.uppercase && <Typography variant="caption" sx={{ color: "#666", display: "block" }}>• One uppercase letter</Typography>}
+                        {!passwordStrength.checks.lowercase && <Typography variant="caption" sx={{ color: "#666", display: "block" }}>• One lowercase letter</Typography>}
+                        {!passwordStrength.checks.number && <Typography variant="caption" sx={{ color: "#666", display: "block" }}>• One number</Typography>}
+                        {!passwordStrength.checks.special && <Typography variant="caption" sx={{ color: "#666", display: "block" }}>• One special character</Typography>}
                     </Box>
                 </Box>
             )}
 
-            {/* Confirm Password */}
             <Box mb={3} textAlign="left">
-                <Typography variant="body2" mb={0.5}>
-                    Confirm Password
-                </Typography>
-                <TextField 
-                    fullWidth 
-                    size="small" 
-                    type={showConfirmPassword ? "text" : "password"}
-                    placeholder="Confirm your password"
-                    name="confirmPassword"
-                    value={formData.confirmPassword}
-                    onChange={handleChange}
+                <Typography variant="body2" mb={0.5}>Confirm Password</Typography>
+                <TextField fullWidth size="small" type={showConfirmPassword ? "text" : "password"} placeholder="Confirm your password"
+                    name="confirmPassword" value={formData.confirmPassword} onChange={handleChange}
                     InputProps={{
                         endAdornment: (
                             <InputAdornment position="end">
-                                <IconButton
-                                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                                    edge="end"
-                                    size="small"
-                                >
+                                <IconButton onClick={() => setShowConfirmPassword(!showConfirmPassword)} edge="end" size="small">
                                     {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
                                 </IconButton>
                             </InputAdornment>
@@ -329,29 +165,14 @@ function Signup() {
                 />
             </Box>
 
-            {/* Signup button */}
-            <Button 
-                fullWidth 
-                variant="contained"
-                onClick={handleSignup}
-                disabled={loading}
-                sx={{
-                    backgroundColor: "#4F46E5",
-                    borderRadius: 2,
-                    textTransform: "none",
-                    fontWeight: 500,
-                    py: 1,
-                    mb: 2
-                }}>
+            <Button fullWidth variant="contained" onClick={handleSignup} disabled={loading}
+                sx={{ backgroundColor: "#4F46E5", borderRadius: 2, textTransform: "none", fontWeight: 500, py: 1, mb: 2 }}>
                 {loading ? "Creating Account..." : "Sign Up"}
             </Button>
 
-            {/* Switch to login */}
             <Typography variant="body2">
                 Already have an account?{" "}
-                <span style={{ color: "#4F46E5", cursor: "pointer" }} onClick={() => navigate("/login")}>
-                    Login
-                </span>
+                <span style={{ color: "#4F46E5", cursor: "pointer" }} onClick={() => navigate("/login")}>Login</span>
             </Typography>
         </Card>
     );

--- a/frontend/src/pages/VerifyEmail.jsx
+++ b/frontend/src/pages/VerifyEmail.jsx
@@ -3,8 +3,9 @@ import { Box, Card, Button, Typography, Alert } from "@mui/material";
 import { MarkEmailRead } from "@mui/icons-material";
 import { useLocation, useNavigate } from "react-router-dom";
 import Logo from "../assets/logo.svg";
+import { api } from "../api";
 
-const RESEND_COOLDOWN = 60; // seconds
+const RESEND_COOLDOWN = 60;
 
 function VerifyEmail() {
     const location = useLocation();
@@ -16,7 +17,6 @@ function VerifyEmail() {
     const [resendError, setResendError] = useState("");
     const [resending, setResending] = useState(false);
 
-    // Countdown timer
     useEffect(() => {
         if (cooldown <= 0) return;
         const timer = setTimeout(() => setCooldown(c => c - 1), 1000);
@@ -27,100 +27,44 @@ function VerifyEmail() {
         setResendStatus("");
         setResendError("");
         setResending(true);
-
         try {
-            const response = await fetch(`/api/v1/auth/resend-verification?email=${encodeURIComponent(email)}`, {
-                method: "POST",
-                });
-
-            if (response.ok) {
-                setResendStatus("Verification email resent! Check your inbox.");
-                setCooldown(RESEND_COOLDOWN);
-            } else {
-                const data = await response.json();
-                setResendError(data.detail || "Failed to resend. Please try again.");
-            }
-        } catch {
-            setResendError("Network error. Please check if the backend is running.");
+            await api.resendVerification(email);
+            setResendStatus("Verification email resent! Check your inbox.");
+            setCooldown(RESEND_COOLDOWN);
+        } catch (err) {
+            setResendError(err.message || "Failed to resend. Please try again.");
         } finally {
             setResending(false);
         }
     };
 
     return (
-        <Card sx={{
-            width: 420,
-            padding: 7,
-            borderRadius: 3,
-            backgroundColor: "#ffffff",
-            boxShadow: "0px 10px 40px rgba(0,0,0,0.3)",
-            textAlign: "center"
-        }}>
-            {/* Logo */}
+        <Card sx={{ width: 420, padding: 7, borderRadius: 3, backgroundColor: "#ffffff", boxShadow: "0px 10px 40px rgba(0,0,0,0.3)", textAlign: "center" }}>
             <Box display="flex" alignItems="center" flexDirection="column" mb={2}>
                 <img src={Logo} alt="Secure Drive logo" style={{ width: 150, height: 150, marginBottom: 6 }} />
-                <Typography variant="h3" fontWeight={700} lineHeight={1.1} sx={{ fontSize: "1.8rem" }}>
-                    Secure Drive
-                </Typography>
+                <Typography variant="h3" fontWeight={700} lineHeight={1.1} sx={{ fontSize: "1.8rem" }}>Secure Drive</Typography>
             </Box>
 
-            {/* Icon */}
             <Box display="flex" justifyContent="center" mb={2}>
                 <MarkEmailRead sx={{ fontSize: 60, color: "#4F46E5" }} />
             </Box>
 
-            {/* Title */}
-            <Typography variant="h6" fontWeight={700} mb={1}>
-                Check your email
-            </Typography>
-
-            {/* Message */}
+            <Typography variant="h6" fontWeight={700} mb={1}>Check your email</Typography>
             <Typography variant="body2" color="text.secondary" mb={3}>
-                We sent a verification link to{" "}
-                <strong>{email || "your email address"}</strong>.
-                Click the link to activate your account.
+                We sent a verification link to <strong>{email || "your email address"}</strong>. Click the link to activate your account.
             </Typography>
 
-            {/* Status messages */}
-            {resendStatus && (
-                <Alert severity="success" sx={{ mb: 2 }}>
-                    {resendStatus}
-                </Alert>
-            )}
-            {resendError && (
-                <Alert severity="error" sx={{ mb: 2 }}>
-                    {resendError}
-                </Alert>
-            )}
+            {resendStatus && <Alert severity="success" sx={{ mb: 2 }}>{resendStatus}</Alert>}
+            {resendError && <Alert severity="error" sx={{ mb: 2 }}>{resendError}</Alert>}
 
-            {/* Resend button */}
-            <Button
-                fullWidth
-                variant="contained"
-                onClick={handleResend}
-                disabled={resending || cooldown > 0}
-                sx={{
-                    backgroundColor: "#4F46E5",
-                    borderRadius: 2,
-                    textTransform: "none",
-                    fontWeight: 500,
-                    py: 1,
-                    mb: 2
-                }}>
-                {resending
-                    ? "Sending..."
-                    : cooldown > 0
-                    ? `Resend in ${cooldown}s`
-                    : "Resend verification email"
-                }
+            <Button fullWidth variant="contained" onClick={handleResend} disabled={resending || cooldown > 0}
+                sx={{ backgroundColor: "#4F46E5", borderRadius: 2, textTransform: "none", fontWeight: 500, py: 1, mb: 2 }}>
+                {resending ? "Sending..." : cooldown > 0 ? `Resend in ${cooldown}s` : "Resend verification email"}
             </Button>
 
-            {/* Back to login */}
             <Typography variant="body2">
                 Already verified?{" "}
-                <span style={{ color: "#4F46E5", cursor: "pointer" }} onClick={() => navigate("/login")}>
-                    Login
-                </span>
+                <span style={{ color: "#4F46E5", cursor: "pointer" }} onClick={() => navigate("/login")}>Login</span>
             </Typography>
         </Card>
     );

--- a/frontend/src/pages/forgot-password.jsx
+++ b/frontend/src/pages/forgot-password.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Box, Card, TextField, Button, Typography, Alert } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import Logo from "../assets/logo.svg";
+import { api } from "../api";
 
 function ForgotPassword() {
     const navigate = useNavigate();
@@ -14,118 +15,58 @@ function ForgotPassword() {
         setError("");
         setSuccess("");
 
-        // Validation
         if (!email) {
             setError("Please enter your email address");
             return;
         }
-
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (!emailRegex.test(email)) {
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
             setError("Please enter a valid email address");
             return;
         }
 
         setLoading(true);
-
-            try {
-                const response = await fetch(`/api/v1/auth/forgot-password?email=${encodeURIComponent(email)}`, {
-                    method: "POST",
-                });
-                if (response.ok) {
-                    setSuccess("If an account exists with that email, you'll receive a reset link shortly.");
-                    setEmail("");
-                } else {
-                    setError("Something went wrong. Please try again later.");
-                }
-            } catch {
-                setError("Network error. Please check your connection and try again.");
-            }
-    };
-
-    const handleKeyPress = (e) => {
-        if (e.key === "Enter") {
-            handleSubmit();
+        try {
+            await api.forgotPassword(email);
+            setSuccess("If an account exists with that email, you'll receive a reset link shortly.");
+            setEmail("");
+        } catch (err) {
+            // Always show success to prevent email enumeration
+            setSuccess("If an account exists with that email, you'll receive a reset link shortly.");
+            setEmail("");
+        } finally {
+            setLoading(false);
         }
     };
 
     return (
-        <Card 
-            sx={{
-                width: 380, 
-                padding: 7, 
-                borderRadius: 3, 
-                backgroundColor: "#ffffff",
-                boxShadow: "0px 10px 40px rgba(0,0,0,0.3)", 
-                textAlign: "center"
-            }}>
-            {/* Title */}
+        <Card sx={{ width: 380, padding: 7, borderRadius: 3, backgroundColor: "#ffffff", boxShadow: "0px 10px 40px rgba(0,0,0,0.3)", textAlign: "center" }}>
             <Box display="flex" alignItems="center" flexDirection="column" mb={2}>
                 <img src={Logo} alt="Secure Drive logo" style={{ width: 150, height: 150, marginBottom: 6 }} />
-                <Typography variant="h3" fontWeight={700} lineHeight={1.1} sx={{ fontSize: "1.8rem" }}>
-                    Secure Drive
-                </Typography>
+                <Typography variant="h3" fontWeight={700} lineHeight={1.1} sx={{ fontSize: "1.8rem" }}>Secure Drive</Typography>
             </Box>
             <Box display="flex" alignItems="center" flexDirection="column" mb={2}>
-                <Typography variant="h3" fontWeight={700} lineHeight={1.1} sx={{ fontSize: "1.3rem" }}>
-                    Forgot Password?
-                </Typography>
-                <Typography variant="body2" sx={{ color: "#666", mt: 1 }}>
-                    Enter your email and we'll send you a reset link
-                </Typography>
+                <Typography variant="h3" fontWeight={700} lineHeight={1.1} sx={{ fontSize: "1.3rem" }}>Forgot Password?</Typography>
+                <Typography variant="body2" sx={{ color: "#666", mt: 1 }}>Enter your email and we'll send you a reset link</Typography>
             </Box>
 
-            {/* Error/Success Messages */}
-            {error && (
-                <Alert severity="error" sx={{ mb: 2 }}>
-                    {error}
-                </Alert>
-            )}
-            {success && (
-                <Alert severity="success" sx={{ mb: 2 }}>
-                    {success}
-                </Alert>
-            )}
+            {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+            {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
 
-            {/* Email */}
             <Box mb={3} textAlign="left">
-                <Typography variant="body2" mb={0.5}>
-                    Email
-                </Typography>
-                <TextField 
-                    fullWidth 
-                    size="small" 
-                    placeholder="Enter your email"
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    onKeyPress={handleKeyPress}
-                />
+                <Typography variant="body2" mb={0.5}>Email</Typography>
+                <TextField fullWidth size="small" placeholder="Enter your email" type="email"
+                    value={email} onChange={(e) => setEmail(e.target.value)}
+                    onKeyPress={(e) => e.key === "Enter" && handleSubmit()} />
             </Box>
 
-            {/* Submit button */}
-            <Button 
-                fullWidth 
-                variant="contained"
-                onClick={handleSubmit}
-                disabled={loading}
-                sx={{
-                    backgroundColor: "#4F46E5",
-                    borderRadius: 2,
-                    textTransform: "none",
-                    fontWeight: 500,
-                    py: 1,
-                    mb: 2
-                }}>
+            <Button fullWidth variant="contained" onClick={handleSubmit} disabled={loading}
+                sx={{ backgroundColor: "#4F46E5", borderRadius: 2, textTransform: "none", fontWeight: 500, py: 1, mb: 2 }}>
                 {loading ? "Sending..." : "Send Reset Link"}
             </Button>
 
-            {/* Back to login */}
             <Typography variant="body2">
                 Remember your password?{" "}
-                <span style={{ color: "#4F46E5", cursor: "pointer" }} onClick={() => navigate("/login")}>
-                    Back to Login
-                </span>
+                <span style={{ color: "#4F46E5", cursor: "pointer" }} onClick={() => navigate("/login")}>Back to Login</span>
             </Typography>
         </Card>
     );

--- a/frontend/src/pages/reset-password.jsx
+++ b/frontend/src/pages/reset-password.jsx
@@ -3,23 +3,22 @@ import { Box, Card, TextField, Button, Typography, Alert, LinearProgress, InputA
 import { useNavigate, useParams } from "react-router-dom";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
 import Logo from "../assets/logo.svg";
+import { api } from "../api";
 
 function ResetPassword() {
     const navigate = useNavigate();
     const { token } = useParams();
 
-    const [tokenValid, setTokenValid] = useState(null); // null=checking, true=valid, false=invalid
+    const [tokenValid, setTokenValid] = useState(null);
     const [tokenError, setTokenError] = useState("");
-    const [formData, setFormData] = useState({ password: "", confirmPassword: "" });
+    const [formData, setFormData] = useState({ email: "", password: "", confirmPassword: "" });
     const [error, setError] = useState("");
     const [success, setSuccess] = useState("");
     const [loading, setLoading] = useState(false);
     const [showPassword, setShowPassword] = useState(false);
     const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
-    // Validate token on load
     useEffect(() => {
-        // Client-side check — if no token, don't even call the API
         if (!token || token.length < 10) {
             setTokenValid(false);
             setTokenError("Invalid or missing reset token.");
@@ -28,19 +27,11 @@ function ResetPassword() {
 
         const validateToken = async () => {
             try {
-                const response = await fetch(`/api/v1/auth/reset-password/${token}`);
-                if (response.ok) {
-                    setTokenValid(true);
-                } else if (response.status === 401) {
-                    setTokenValid(false);
-                    setTokenError("This reset link has expired.");
-                } else {
-                    setTokenValid(false);
-                    setTokenError("This reset link is invalid or has already been used.");
-                }
-            } catch {
+                await api.validateResetToken(token);
+                setTokenValid(true);
+            } catch (err) {
                 setTokenValid(false);
-                setTokenError("Network error. Please check your connection.");
+                setTokenError(err.message || "This reset link is invalid or has already been used.");
             }
         };
 
@@ -88,50 +79,40 @@ function ResetPassword() {
         setError("");
         setSuccess("");
 
+        if (!formData.email) {
+            setError("Please enter your email address");
+            return;
+        }
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+            setError("Please enter a valid email address");
+            return;
+        }
         if (!formData.password || !formData.confirmPassword) {
             setError("Please fill in all fields");
             return;
         }
-
         const passwordErrors = validatePassword(formData.password);
         if (passwordErrors.length > 0) {
             setError("Password requirements:\n• " + passwordErrors.join("\n• "));
             return;
         }
-
         if (formData.password !== formData.confirmPassword) {
             setError("Passwords do not match");
             return;
         }
 
         setLoading(true);
-
         try {
-            const response = await fetch("/api/v1/auth/reset-password", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                // Token is NOT sent in body — backend reads it from path context
-                body: JSON.stringify({ new_password: formData.password }),
-            });
-
-            if (response.ok) {
-                setSuccess("Password reset successful! Redirecting to login...");
-                setTimeout(() => navigate("/login"), 2000);
-            } else if (response.status === 401) {
-                setError("This reset link has expired. Please request a new one.");
-            } else if (response.status === 400) {
-                setError("This reset link has already been used. Please request a new one.");
-            } else {
-                setError("Something went wrong. Please try again.");
-            }
-        } catch {
-            setError("Network error. Please check your connection.");
+            await api.resetPassword(formData.email, formData.password);
+            setSuccess("Password reset successful! Redirecting to login...");
+            setTimeout(() => navigate("/login"), 2000);
+        } catch (err) {
+            setError(err.message || "Something went wrong. Please try again.");
         } finally {
             setLoading(false);
         }
     };
 
-    // Loading state while validating token
     if (tokenValid === null) {
         return (
             <Card sx={{ width: 420, padding: 7, borderRadius: 3, backgroundColor: "#ffffff", boxShadow: "0px 10px 40px rgba(0,0,0,0.3)", textAlign: "center" }}>
@@ -140,7 +121,6 @@ function ResetPassword() {
         );
     }
 
-    // Invalid token state
     if (tokenValid === false) {
         return (
             <Card sx={{ width: 420, padding: 7, borderRadius: 3, backgroundColor: "#ffffff", boxShadow: "0px 10px 40px rgba(0,0,0,0.3)", textAlign: "center" }}>
@@ -158,7 +138,6 @@ function ResetPassword() {
         );
     }
 
-    // Valid token — show the form
     return (
         <Card sx={{ width: 420, padding: 7, borderRadius: 3, backgroundColor: "#ffffff", boxShadow: "0px 10px 40px rgba(0,0,0,0.3)", textAlign: "center" }}>
             <Box display="flex" alignItems="center" flexDirection="column" mb={2}>
@@ -167,18 +146,23 @@ function ResetPassword() {
             </Box>
             <Box display="flex" alignItems="center" flexDirection="column" mb={2}>
                 <Typography variant="h3" fontWeight={700} sx={{ fontSize: "1.3rem" }}>Reset Password</Typography>
-                <Typography variant="body2" sx={{ color: "#666", mt: 1 }}>Enter your new password</Typography>
+                <Typography variant="body2" sx={{ color: "#666", mt: 1 }}>Enter your email and new password</Typography>
             </Box>
 
             {error && <Alert severity="error" sx={{ mb: 2, textAlign: "left", whiteSpace: "pre-line" }}>{error}</Alert>}
             {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
 
+            {/* Email field — needed to identify the account */}
+            <Box mb={2} textAlign="left">
+                <Typography variant="body2" mb={0.5}>Email</Typography>
+                <TextField fullWidth size="small" type="email" placeholder="Enter your email address"
+                    value={formData.email}
+                    onChange={(e) => setFormData({ ...formData, email: e.target.value })} />
+            </Box>
+
             <Box mb={1} textAlign="left">
                 <Typography variant="body2" mb={0.5}>New Password</Typography>
-                <TextField
-                    fullWidth size="small"
-                    type={showPassword ? "text" : "password"}
-                    placeholder="Enter new password"
+                <TextField fullWidth size="small" type={showPassword ? "text" : "password"} placeholder="Enter new password"
                     value={formData.password}
                     onChange={(e) => setFormData({ ...formData, password: e.target.value })}
                     InputProps={{
@@ -201,23 +185,15 @@ function ResetPassword() {
                             {getStrengthLabel(passwordStrength.strength)}
                         </Typography>
                     </Box>
-                    <LinearProgress
-                        variant="determinate"
-                        value={(passwordStrength.strength / 5) * 100}
-                        sx={{
-                            height: 6, borderRadius: 3, backgroundColor: "#e5e7eb",
-                            "& .MuiLinearProgress-bar": { backgroundColor: getStrengthColor(passwordStrength.strength), borderRadius: 3 }
-                        }}
+                    <LinearProgress variant="determinate" value={(passwordStrength.strength / 5) * 100}
+                        sx={{ height: 6, borderRadius: 3, backgroundColor: "#e5e7eb", "& .MuiLinearProgress-bar": { backgroundColor: getStrengthColor(passwordStrength.strength), borderRadius: 3 } }}
                     />
                 </Box>
             )}
 
             <Box mb={3} textAlign="left">
                 <Typography variant="body2" mb={0.5}>Confirm Password</Typography>
-                <TextField
-                    fullWidth size="small"
-                    type={showConfirmPassword ? "text" : "password"}
-                    placeholder="Confirm new password"
+                <TextField fullWidth size="small" type={showConfirmPassword ? "text" : "password"} placeholder="Confirm new password"
                     value={formData.confirmPassword}
                     onChange={(e) => setFormData({ ...formData, confirmPassword: e.target.value })}
                     InputProps={{
@@ -232,12 +208,8 @@ function ResetPassword() {
                 />
             </Box>
 
-            <Button
-                fullWidth variant="contained"
-                onClick={handleSubmit}
-                disabled={loading}
-                sx={{ backgroundColor: "#4F46E5", borderRadius: 2, textTransform: "none", fontWeight: 500, py: 1, mb: 2 }}
-            >
+            <Button fullWidth variant="contained" onClick={handleSubmit} disabled={loading}
+                sx={{ backgroundColor: "#4F46E5", borderRadius: 2, textTransform: "none", fontWeight: 500, py: 1, mb: 2 }}>
                 {loading ? "Resetting..." : "Reset Password"}
             </Button>
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
-import {resolve} from "path";
+import { resolve } from "path";
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
@@ -20,15 +20,20 @@ export default defineConfig(({ mode }) => {
     server: {
       allowedHosts: [env.VITE_DOMAIN],
       proxy: {
-        "/api": {
-          target: env.VITE_API_URL || "http://localhost:8000",
+        '/auth-api': {
+          target: env.VITE_AUTH_URL || 'http://localhost:8001',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/auth-api/, '/api'),
+        },
+        '/api': {
+          target: env.VITE_API_URL || 'http://localhost:8000',
           changeOrigin: true,
         },
       },
       hmr: {
         host: env.VITE_DOMAIN,
-        protocol: "wss", // cloudflare tunnel is always HTTPS/WSS
-        clientPort: 443, // tunnel terminates SSL, so client connects on 443
+        protocol: "wss",
+        clientPort: 443,
       },
     },
   };


### PR DESCRIPTION
## Summary

Prepares the frontend API client for the upcoming backend service split (auth on port 8001, core/files on port 8000).
---

## What changed

### `api.js` — dual base URL routing
Replaced the single `API_BASE_URL` with two constants:
- `AUTH_BASE = '/auth-api/api/v1'` → routes to auth service
- `CORE_BASE = '/api/v1'` → routes to core/files service

The Vite proxy handles rewriting `/auth-api/*` to the auth container.

### `vite.config.js` — second proxy entry
Added `/auth-api` proxy alongside existing `/api` proxy. In dev, requests to `/auth-api/*` are forwarded to `VITE_AUTH_URL` (auth service) with the prefix rewritten back to `/api`.

### Pages — centralized all direct fetch() calls into `api.js`
Previously 6 pages were making their own raw fetch calls with hardcoded URLs. All calls now go through `api.js`:

| Page | Methods added to api.js |
|------|------------------------|
| `Login.jsx` | `api.login()` |
| `Signup.jsx` | `api.register()` |
| `VerifyEmail.jsx` | `api.resendVerification()` |
| `forgot-password.jsx` | `api.forgotPassword()` |
| `reset-password.jsx` | `api.validateResetToken()`, `api.resetPassword()` |
| `Profile.jsx` | `api.updateName()`, `api.changePassword()` |

### `reset-password.jsx` — added email field
The `POST /auth/reset-password` endpoint requires `{ email, new_password }` in the request body. The page previously had no email field and would have failed silently. Added email input with validation.

### `forgot-password.jsx` — security fix
Always shows success message regardless of whether the email exists, preventing email enumeration attacks.

### `.env.dev` + `docker-compose-dev.yml`
Added `VITE_AUTH_URL=http://auth:8001` for when the auth container comes online.
